### PR TITLE
fatelf-exec: Execute FatElf binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(FatELF)
 
+include(CheckSymbolExists)
+include(GNUInstallDirs)
+
 execute_process(
     COMMAND git rev-list HEAD~..
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -36,6 +39,20 @@ add_fatelf_executable(fatelf-remove)
 add_fatelf_executable(fatelf-verify)
 add_fatelf_executable(fatelf-split)
 add_fatelf_executable(fatelf-validate)
+
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(memfd_create sys/mman.h MEMFD)
+check_symbol_exists(fexecve unistd.h FEXECVE)
+if(MEMFD AND FEXECVE AND EXISTS /proc/self/exe)
+    add_fatelf_executable(fatelf-exec)
+
+    find_program(BINFMT systemd-binfmt PATHS /usr/lib/systemd)
+    if(BINFMT)
+        configure_file(fatelf.conf.in fatelf.conf)
+        install(DIRECTORY DESTINATION ${CMAKE_INSTALL_LIBDIR}/binfmt.d)
+        install(FILES ${CMAKE_BINARY_DIR}/fatelf.conf DESTINATION ${CMAKE_INSTALL_LIBDIR}/binfmt.d/)
+    endif()
+endif()
 
 # end of CMakeLists.txt ...
 

--- a/fatelf.conf.in
+++ b/fatelf.conf.in
@@ -1,0 +1,1 @@
+:fatelf-v1:M::\xFA\x70\x0E\x1F\x01\x00::${CMAKE_INSTALL_FULL_BINDIR}/fatelf-exec:

--- a/utils/fatelf-exec.c
+++ b/utils/fatelf-exec.c
@@ -1,0 +1,49 @@
+/**
+ * FatELF; support multiple ELF binaries in one file.
+ *
+ * Please see the file LICENSE.txt in the source's root directory.
+ *
+ *  This file written by Henry W. Wilson.
+ */
+
+#define _GNU_SOURCE
+#define FATELF_UTILS 1
+#include "fatelf-utils.h"
+#include <sys/mman.h>
+#include <unistd.h>
+
+static FATELF_record * xfind_matching_record(FATELF_record const *tgt, FATELF_header *header)
+{
+    for (uint8_t i = 0; i < header->num_records; i++)
+	if (fatelf_record_matches(header->records + i, tgt))
+		return header->records + i;
+
+    xfail("Unable to find %s in FatElf records", fatelf_get_target_name(tgt, FATELF_WANT_EVERYTHING));
+} // xfind_matching_record
+
+int main(int argc, char *argv[], char *envp[])
+{
+    xfatelf_init(argc, (char const**)argv);
+    if (argc < 2)
+        xfail("USAGE: %s [--version] fatelf-file [args...]", argv[0]);
+
+    int fd = xopen(argv[1], O_RDONLY | O_CLOEXEC, 0);
+    FATELF_header *header = xread_fatelf_header(argv[1], fd);
+
+    int self = xopen("/proc/self/exe", O_RDONLY | O_CLOEXEC, 0);
+    FATELF_record self_elf;
+    xread_elf_header(argv[0], self, 0, &self_elf);
+
+    FATELF_record const *rec = xfind_matching_record(&self_elf, header);
+
+    int outfd = memfd_create("ELF", MFD_CLOEXEC);
+    if (outfd < 0)
+        xfail("memfd_create");
+
+    xcopyfile_range(argv[1], fd, "memfd:ELF", outfd, rec->offset, rec->size);
+
+    fexecve(outfd, (argv + 1), envp);
+    xfail("fexecve");
+} // main
+
+// end of fatelf-exec.c ...

--- a/utils/fatelf-utils.c
+++ b/utils/fatelf-utils.c
@@ -73,7 +73,7 @@ const char *fatelf_build_version = MAKEBUILDVERSTRINGLITERAL(APPID, APPREV);
 
 
 // Report an error to stderr and terminate immediately with exit(1).
-void xfail(const char *fmt, ...)
+[[noreturn]] void xfail(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);

--- a/utils/fatelf-utils.h
+++ b/utils/fatelf-utils.h
@@ -57,7 +57,7 @@ typedef struct fatelf_osabi_info
 // all functions that start with 'x' may call exit() on error!
 
 // Report an error to stderr and terminate immediately with exit(1).
-void xfail(const char *fmt, ...) FATELF_ISPRINTF(1,2);
+[[noreturn]] void xfail(const char *fmt, ...) FATELF_ISPRINTF(1,2);
 
 // Wrap malloc() with an xfail(), so this returns memory or calls exit().
 // Memory is guaranteed to be initialized to zero.


### PR DESCRIPTION
Thanks for your work coming up with a sensible spec. I stumbled across `systemd-binfmt` recently and remembered FatElf.

As it stands, `fatelf-exec` copies the contained ELF into an anonymous memory backed file and executes it. This works for statically linked binaries and dynamically linked binaries that are linked to normal ELF dynamic libraries.
For the use case of FatElf dynamic libraries, this does not provide a solution, though it could be possible in theory to shim `ld-linux.so` somehow.

It turns out there _is_ demand for this sort of thing. Though it seems one only gets support when done with clever tricks: [APE](https://justine.lol/ape.html)